### PR TITLE
Fix readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,8 @@ variable "secret_key" {
 terraform {
     required_providers {
       cyberark = {
-        source  = “registry.terraform.io/cyberark/cyberark"version = "~> 0"
+        source  = "registry.terraform.io/cyberark/cyberark"
+        version = "~> 0"
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ resource "cyberark_safe" "AAM_Test_Safe" {
   member             = "demo@cyberark.cloud.aarp0000"
   member_type        = "user"
   permission_level   = "read" # full, read, approver, manager
+  # Define either retention (days) or retention_versions. Defining both will result in an error from the API.
   retention          = 7
   retention_versions = 7
   purge              = false
@@ -282,6 +283,7 @@ resource "cyberark_safe" "PCloud_Test_Safe" {
   member             = "demo@cyberark.cloud.aarp0000"
   member_type        = "user"
   permission_level   = "read" # full, read, approver, manager
+  # Define either retention (days) or retention_versions. Defining both will result in an error from the API.
   retention          = 7
   retention_versions = 7
   purge              = false
@@ -321,6 +323,7 @@ resource "cyberark_pam_safe" "PAM_Test_Safe" {
   member             = "demo@cyberark.cloud.aarp0000"
   member_type        = "user"
   permission_level   = "read" # full, read, approver, manager
+  # Define either retention (days) or retention_versions. Defining both will result in an error from the API.
   retention          = 7
   retention_versions = 7
   purge              = false


### PR DESCRIPTION
### Desired Outcome

The examples in the README do not work. Either there are strange characters or the example `cyberark_safe` resource has both `retention` and `retention_versions` defined, which results in a 400 error from the CyberArk PAM API.

### Implemented Changes

The README was updated.

### Connected Issue/Story

N/A

### Definition of Done

N/A

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
